### PR TITLE
Change 'clevor' to 'clever' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
  - [x] Player skill editor.
  
 ## How It Works / How Do I Use It?
-Due to how Core Keeper is as a unity game, the devolopers have protected their source and mono files. To further aid in the no support for modding this game includes, they also have used memory protection techniques to scramble regions of memory to prevent address pointers. So using some clevor AoB (array of bytes) scanning, we can get around this protection due to some unspecified exploits that exists within their protection.
+Due to how Core Keeper is as a unity game, the devolopers have protected their source and mono files. To further aid in the no support for modding this game includes, they also have used memory protection techniques to scramble regions of memory to prevent address pointers. So using some clever AoB (array of bytes) scanning, we can get around this protection due to some unspecified exploits that exists within their protection.
 
 Included in this application's directory is a file named `build.bat`. This file can be used to compile the applications source code from a single click. You can also download an already compiled version from the releases. After building, your application can be found in the releases directory. If you downloaded it pre-compiled, you will need to simply extract it to any desired location.
 


### PR DESCRIPTION
I tried searching for my blog to see if it was on Google yet, and I saw this README.